### PR TITLE
Fix long parameter padding

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -4,7 +4,7 @@ use crate::param::SendParam;
 
 pub trait SendParams {
     fn len(&self, long: bool) -> usize {
-        self.param_len(long) + if long { 2 } else { 1 }
+        self.param_len(long) + 1
     }
 
     fn param_len(&self, long: bool) -> usize;

--- a/src/transport/spi.rs
+++ b/src/transport/spi.rs
@@ -81,7 +81,7 @@ where
             // Pad to 4 byte boundary
             let mut total_len = send_params.len(long_send) + 3;
             while 0 != total_len % 4 {
-                Self::send_byte(spi, 0)?;
+                Self::send_byte(spi, 0xff)?;
                 total_len += 1;
             }
 


### PR DESCRIPTION
The parameter send code correctly deals with the case where the parameter length itself needs to be two bytes
rather than one, however it mistakenly also extends the parameter count field in the command header itself.

Correct this to only add one byte for the parameter count.