### PR TITLE
Invert reset logic with feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wifi-nina"
-version = "0.1.3-alpha.0"
+version = "0.1.3-alpha.1"
 authors = ["David Flemström <david.flemstrom@gmail.com>"]
 edition = "2018"
 description = "An embedded driver for ublox NINA-W10-based WiFi boards (using ESP32), present on some Arduinos, or using the Adafruit AirLift series of chips"
@@ -20,3 +20,9 @@ log = { version = "0.4.11", default-features = false }
 nb = { version = "1.0", default-features = false }
 no-std-net = { version = "0.5.0", default-features = false }
 num_enum = { version = "0.5.1", default-features = false }
+
+[features]
+default = []
+# reset-high inverts the reset logic to go to high and then low instead of low and then high
+# this is needed on the Arduino MKR WiFi 1010 for example
+reset-high = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["embedded", "hardware-support", "no-std"]
 arrayvec = { version = "0.5.1", default-features = false }
 byteorder = { version = "1.3.4", default-features = false }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
-itertools = { version = "0.9.0", default-features = false }
+itertools = { version = "0.10.0", default-features = false }
 log = { version = "0.4.11", default-features = false }
-nb = { version = "0.1.2", default-features = false }
-no-std-net = { version = "0.4.0", default-features = false }
+nb = { version = "1.0", default-features = false }
+no-std-net = { version = "0.5.0", default-features = false }
 num_enum = { version = "0.5.1", default-features = false }

--- a/src/params.rs
+++ b/src/params.rs
@@ -4,7 +4,7 @@ use crate::param::SendParam;
 
 pub trait SendParams {
     fn len(&self, long: bool) -> usize {
-        self.param_len(long) + if long { 2 } else { 1 }
+        self.param_len(long) + 1
     }
 
     fn param_len(&self, long: bool) -> usize;

--- a/src/transport/spi.rs
+++ b/src/transport/spi.rs
@@ -45,9 +45,18 @@ where
     fn reset(&mut self) -> Result<(), Self::Error> {
         self.cs.set_high().map_err(SpiError::ChipSelect)?;
 
-        self.reset.set_low().map_err(SpiError::Reset)?;
-        self.delay(time::Duration::from_millis(10))?;
+        #[cfg(feature = "reset-high")]
         self.reset.set_high().map_err(SpiError::Reset)?;
+        #[cfg(not(feature = "reset-high"))]
+        self.reset.set_low().map_err(SpiError::Reset)?;
+
+        self.delay(time::Duration::from_millis(10))?;
+
+        #[cfg(feature = "reset-high")]
+        self.reset.set_low().map_err(SpiError::Reset)?;
+        #[cfg(not(feature = "reset-high"))]
+        self.reset.set_high().map_err(SpiError::Reset)?;
+
         self.delay(time::Duration::from_millis(750))?;
 
         Ok(())

--- a/src/transport/spi.rs
+++ b/src/transport/spi.rs
@@ -81,7 +81,7 @@ where
             // Pad to 4 byte boundary
             let mut total_len = send_params.len(long_send) + 3;
             while 0 != total_len % 4 {
-                Self::send_byte(spi, 0)?;
+                Self::send_byte(spi, 0xff)?;
                 total_len += 1;
             }
 


### PR DESCRIPTION
This optional feature makes it possible to use this lib on the Arduino MKR WiFi 1010 where the reset logic is inverted (for some reason).